### PR TITLE
Fix Python 3 incompatibility with cookielib

### DIFF
--- a/sumologic/sumologic.py
+++ b/sumologic/sumologic.py
@@ -2,7 +2,11 @@ from copy import copy
 import json
 import logging
 import requests
-import cookielib
+
+try:
+    import cookielib
+except ImportError:
+    import http.cookiejar as cookielib
 
 class SumoLogic(object):
 


### PR DESCRIPTION
Following up on issue #6, this PR fixes Python 3 compatibility by adding a check for the renamed version of `cookielib`.

It would be great to get this released to PyPI!