### PR TITLE
Fix for limit check when 0 records are returned.

### DIFF
--- a/scripts/search-job-messages.py
+++ b/scripts/search-job-messages.py
@@ -42,6 +42,6 @@ print status['state']
 
 if status['state'] == 'DONE GATHERING RESULTS':
     count = status['messageCount']
-    limit = count if count < LIMIT else LIMIT # compensate bad limit check
+    limit = count if count < LIMIT and count != 0 else LIMIT # compensate bad limit check
     r = sumo.search_job_messages(sj, limit=limit)
     print r

--- a/scripts/search-job.py
+++ b/scripts/search-job.py
@@ -45,6 +45,6 @@ print status['state']
 
 if status['state'] == 'DONE GATHERING RESULTS':
     count = status['recordCount']
-    limit = count if count < LIMIT else LIMIT # compensate bad limit check
+    limit = count if count < LIMIT and count != 0 else LIMIT # compensate bad limit check
     r = sumo.search_job_records(sj, limit=limit)
     print r


### PR DESCRIPTION
If 0 records are returned by a query, the call to /records fails because it sets the LIMIT to the number of records returned. SumoLogic responds with a 400 error if &limit=0. This will use the set limit instead of  overriding with 0 in these instances.  