### PR TITLE
update delay behavior when checking SearchJob status

### DIFF
--- a/scripts/search-job-messages.py
+++ b/scripts/search-job-messages.py
@@ -26,7 +26,7 @@ fromTime = args[3]
 toTime = args[4]
 timeZone = args[5]
 
-delay = 2
+delay = 5
 q = ' '.join(sys.stdin.readlines())
 sj = sumo.search_job(q, fromTime, toTime, timeZone)
 
@@ -35,7 +35,6 @@ while status['state'] != 'DONE GATHERING RESULTS':
 	if status['state'] == 'CANCELLED':
 		break
 	time.sleep(delay)
-	delay *= 2
 	status = sumo.search_job_status(sj)
 
 print status['state']

--- a/scripts/search-job.py
+++ b/scripts/search-job.py
@@ -29,7 +29,7 @@ fromTime = args[4]
 toTime = args[5]
 timeZone = args[6]
 
-delay = 2
+delay = 5
 q = ' '.join(sys.stdin.readlines())
 sj = sumo.search_job(q, fromTime, toTime, timeZone)
 
@@ -38,7 +38,6 @@ while status['state'] != 'DONE GATHERING RESULTS':
     if status['state'] == 'CANCELLED':
         break
     time.sleep(delay)
-    delay *= 2
     status = sumo.search_job_status(sj)
 
 print status['state']


### PR DESCRIPTION
update delay behavior when checking SearchJob status.  The current behavior is to check after the 2 seconds, and then 4, then 8, etc.  Changed to be same behavior in Java SDK example, check after 5 seconds, and then every 5 seconds until the job completes or cancels.