### PR TITLE
Fix Missing Collector Id reference

### DIFF
--- a/sumologic/sumologic.py
+++ b/sumologic/sumologic.py
@@ -102,7 +102,7 @@ class SumoLogic(object):
         return self.put('/collectors/' + str(collector['collector']['id']), collector, headers)
 
     def delete_collector(self, collector):
-        return self.delete('/collectors/' + str(collector['id']))
+        return self.delete('/collectors/' + str(collector['collector']['id']))
 
     def sources(self, collector_id, limit=None, offset=None):
         params = {'limit': limit, 'offset': offset}


### PR DESCRIPTION
This PR fixes a wrong reference to the collector id in the delete_collector function.