### PR TITLE
Add field byReceiptTime to search job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). The CHANGELOG
 ### Added
 - Added search job deletion support via PR24
 - Added support for metrics queries via PR25
+- Added new parameter byReceiptTime to create search job api
 
 ### Changed
 - Fixed import issue for py27/py36 users via PR22

--- a/scripts/search-job-messages.py
+++ b/scripts/search-job-messages.py
@@ -2,7 +2,7 @@
 # (as opposed to records).  Pass the query via stdin.
 #
 # cat query.sumoql | python search-job-messages.py <accessId> <accessKey> \
-# <fromDate> <toDate> <timeZone>
+# <fromDate> <toDate> <timeZone> <byReceiptTime>
 #
 # Note: fromDate and toDate must be either ISO 8601 date-times or epoch
 #       milliseconds
@@ -10,7 +10,7 @@
 # Example:
 #
 # cat query.sumoql | python search-job-messages.py <accessId> <accessKey> \
-# 1408643380441 1408649380441 PST
+# 1408643380441 1408649380441 PST false
 
 import json
 import sys
@@ -25,10 +25,11 @@ sumo = SumoLogic(args[1], args[2])
 fromTime = args[3]
 toTime = args[4]
 timeZone = args[5]
+byReceiptTime = args[6]
 
 delay = 5
 q = ' '.join(sys.stdin.readlines())
-sj = sumo.search_job(q, fromTime, toTime, timeZone)
+sj = sumo.search_job(q, fromTime, toTime, timeZone, byReceiptTime)
 
 status = sumo.search_job_status(sj)
 while status['state'] != 'DONE GATHERING RESULTS':

--- a/scripts/search-job.py
+++ b/scripts/search-job.py
@@ -2,7 +2,7 @@
 # Pass the query via stdin.
 #
 # cat query.sumoql | python search-job.py <accessId> <accessKey> \
-# <endpoint> <fromDate> <toDate> <timeZone>
+# <endpoint> <fromDate> <toDate> <timeZone> <byReceiptTime>
 #
 # Note: fromDate and toDate must be either ISO 8601 date-times or epoch
 #       milliseconds
@@ -10,7 +10,7 @@
 # Example:
 #
 # cat query.sumoql | python search-job.py <accessId> <accessKey> \
-# https://api.us2.sumologic.com/api/v1/ 1408643380441 1408649380441 PST
+# https://api.us2.sumologic.com/api/v1/ 1408643380441 1408649380441 PST false
 
 import json
 import sys
@@ -28,10 +28,11 @@ sumo = SumoLogic(args[1], args[2], args[3])
 fromTime = args[4]
 toTime = args[5]
 timeZone = args[6]
+byReceiptTime = args[7]
 
 delay = 5
 q = ' '.join(sys.stdin.readlines())
-sj = sumo.search_job(q, fromTime, toTime, timeZone)
+sj = sumo.search_job(q, fromTime, toTime, timeZone, byReceiptTime)
 
 status = sumo.search_job_status(sj)
 while status['state'] != 'DONE GATHERING RESULTS':

--- a/sumologic/sumologic.py
+++ b/sumologic/sumologic.py
@@ -66,8 +66,8 @@ class SumoLogic(object):
         r = self.get('/logs/search', params)
         return json.loads(r.text)
 
-    def search_job(self, query, fromTime=None, toTime=None, timeZone='UTC'):
-        params = {'query': query, 'from': fromTime, 'to': toTime, 'timeZone': timeZone}
+    def search_job(self, query, fromTime=None, toTime=None, timeZone='UTC', byReceiptTime=None):
+        params = {'query': query, 'from': fromTime, 'to': toTime, 'timeZone': timeZone, 'byReceiptTime': byReceiptTime}
         r = self.post('/search/jobs', params)
         return json.loads(r.text)
 


### PR DESCRIPTION
The sumo api already supports the byReceiptTime, but the python sdk doesn't accept this parameter yet. This parameter is added to the search_job endpoint (defaults to message time).