### PR TITLE
Validate for trailing slash

### DIFF
--- a/scripts/search-job.py
+++ b/scripts/search-job.py
@@ -10,7 +10,7 @@
 # Example:
 #
 # cat query.sumoql | python search-job.py <accessId> <accessKey> \
-# https://api.us2.sumologic.com/api/v1/ 1408643380441 1408649380441 PST false
+# https://api.us2.sumologic.com/api/v1 1408643380441 1408649380441 PST false
 
 import json
 import sys

--- a/sumologic/sumologic.py
+++ b/sumologic/sumologic.py
@@ -20,6 +20,8 @@ class SumoLogic(object):
             self.endpoint = self._get_endpoint()
         else:
             self.endpoint = endpoint
+        if endpoint[-1:] == "/":
+          raise Exception("Endpoint should not end with a slash character")
 
     def _get_endpoint(self):
         """


### PR DESCRIPTION
Preventing a HTTP 500 Internal Server Error when the endpoint URL ends with a Slash