### PR TITLE
added get_available_builds function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/). The CHANGELOG
 - Added search job deletion support via PR24
 - Added support for metrics queries via PR25
 - Added new parameter byReceiptTime to create search job api
+- Added new get_available_builds function
 
 ### Changed
 - Fixed import issue for py27/py36 users via PR22

--- a/sumologic/sumologic.py
+++ b/sumologic/sumologic.py
@@ -166,3 +166,7 @@ class SumoLogic(object):
                   'maxDataPoints': maxDataPoints}
         r = self.post('/metrics/results', params)
         return json.loads(r.text)
+
+    def get_available_builds(self):
+        r = self.get('/collectors/upgrades/targets')
+        return json.loads(r.text)['targets']


### PR DESCRIPTION
Needed a way to get the following endpoint so I added it.

https://help.sumologic.com/APIs/01Collector-Management-API/Upgrade-or-Downgrade-Collectors-Using-the-API#get-available-builds