### PR TITLE
remove deprecated api endpoint /api/v1/logs/search

### DIFF
--- a/sumologic/sumologic.py
+++ b/sumologic/sumologic.py
@@ -109,11 +109,6 @@ class SumoLogic(object):
         return r
 
     # Logs Search
-    def search(self, query, fromTime=None, toTime=None, timeZone='UTC'):
-        params = {'q': query, 'from': fromTime, 'to': toTime, 'tz': timeZone}
-        r = self.get('/logs/search', params)
-        return json.loads(r.text)
-
     def search_job(self, query, fromTime=None, toTime=None, timeZone='UTC', byReceiptTime=None):
         params = {'query': query, 'from': fromTime, 'to': toTime, 'timeZone': timeZone, 'byReceiptTime': byReceiptTime}
         r = self.post('/search/jobs', params)


### PR DESCRIPTION
On 1 Mar 2023, Sumo Logic will be removing support for our older search API, which is called with the following HTTP endpoint:

US1 Deployment: https://api.sumologic.com/api/v1/logs/search
All Other Deployments: https://api.<your-deployment>.sumologic.com/api/v1/logs/search
In the 2017 timeframe, Sumo Logic released the [Search Job API](https://help.sumologic.com/APIs/Search-Job-API/About-the-Search-Job-API), which was designed to replace the original version with a more robust, scalable solution. While the older endpoint has remained available, it is deprecated as it is no longer being supported by our Product and Engineering Teams.