### PR TITLE
Add method for get_content_item_by_path

### DIFF
--- a/sumologic/sumologic.py
+++ b/sumologic/sumologic.py
@@ -291,8 +291,6 @@ class SumoLogic(object):
         return self.post('/content/%s/move?destinationFolderId=%s' % (content_id, destination_folder), params=None,
                          version='v2')
 
-    # Additions
-
     def get_content_item_by_path(self, path):
         return self.get('/content/path?path=%s' % (path), params=None, version='v2')
 

--- a/sumologic/sumologic.py
+++ b/sumologic/sumologic.py
@@ -291,6 +291,11 @@ class SumoLogic(object):
         return self.post('/content/%s/move?destinationFolderId=%s' % (content_id, destination_folder), params=None,
                          version='v2')
 
+    # Additions
+
+    def get_content_item_by_path(self, path):
+        return self.get('/content/path?path=%s' % (path), params=None, version='v2')
+
     # Lookup
     def create_lookup_table(self, content):
         return self.post('/lookupTables', params=content, version='v1')


### PR DESCRIPTION
This PR adds a single GET request to the SDK to get content item by path. 

This is useful for easily retrieving items from the user's Personal folder. 